### PR TITLE
routesでbookmarksコントローラに紐づくルーティングをpassagesリソースにネストさせた

### DIFF
--- a/app/views/shared/_passage_cards.html.erb
+++ b/app/views/shared/_passage_cards.html.erb
@@ -16,7 +16,7 @@
       <%= link_to passage.user_name, user_path(passage.user_id), class: "hover:text-gray-50" %>
     </div>
     <div class="flex w-3/12">
-      <%= link_to "users/test_user_1/passages/#{passage.id}/bookmarks/check", method: :post do %>
+      <%= link_to user_passage_bookmarks_check_path(user_id: "test_user_1", passage_id: passage.id), method: :post do %>
       <i class="far fa-bookmark mr-1.5"></i>
       <% end %>
       <%= link_to passage_bookmarks, controller: "bookmarks", action: "show_passage_bookmarks", user_id: passage.user_id, passage_id: passage.id%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,12 @@
 Rails.application.routes.draw do
   root 'passages#show_all'
-  get 'users/:user_id/passages/:passage_id/bookmarks', to: 'bookmarks#show_passage_bookmarks'
-  post 'users/:user_id/passages/:passage_id/bookmarks/check', to: 'bookmarks#try_create_bookmark'
 
   resources :users, path_names: { new: 'signup' } do
-    resource :bookmarks, { only: %i[show] } # TODO: bookmarks用のコントローラ作成
-    resources :passages, { only: %i[create destroy show] }
+    resource :bookmarks, { only: %i[show] }
+    resources :passages, { only: %i[create destroy show] } do
+      get 'bookmarks', to: 'bookmarks#show_passage_bookmarks'
+      post 'bookmarks/check', to: 'bookmarks#try_create_bookmark'
+    end
     resources :comments, { only: %i[create destroy show] }
   end
 


### PR DESCRIPTION
理由：これまでのbookmarksコントローラに紐づくルーティングは本来passagesリソースで生成されるurlの末尾に追加で文字列を増やしたものなので